### PR TITLE
Fixes #6 pyodide module resolution for esm modules

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,7 @@ const es6 = {
       type: "module",
     },
   },
+  externals: [nodeExternals({ importType: "module" })],
   module: {
     rules: [
       {


### PR DESCRIPTION
Error: Require is not defined was being thrown when using the .mjs module build of this package. The issue is that require calls were being hardcoded in a couple places (incompatible with esm).

To resolve the issue we had to fix a few things:

 - Resolving the pyodide package location for copying files
 - Determining the exact pyodide version installed on disk

require.resolve was the solution that was failing. Unfortunately, there is no stable way to resolve an ES Module in node yet. There is an experimental module.meta.require and a way to break back out to commonjs by importing createRequire from module. However, those methods are themselves hacks, require certain webpack targets, or are not supported in older versions of node.

The fix is to use the filesystem and naively search in {PWD}/node_modules
for the correct pyodide dependency and version. In case of failure we also added 2 new options to configure / override the new behavior.