### PR TITLE
Remove distutils.tar from copied files

### DIFF
--- a/lib/patterns.ts
+++ b/lib/patterns.ts
@@ -15,6 +15,14 @@ const files = {
     "pyodide.asm.wasm",
     "repodata.json",
   ],
+  "0.22.1": [
+    "package.json",
+    "pyodide_py.tar",
+    "pyodide.asm.js",
+    "pyodide.asm.data",
+    "pyodide.asm.wasm",
+    "repodata.json",
+  ],
 };
 export const versions = Object.keys(files);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,12 +21,14 @@
         "lodash": "^4.17.21",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.7.1",
-        "pyodide": "^0.21.3",
         "ts-loader": "^9.4.1",
         "typescript": "^4.8.3",
         "webpack": "^5.74.0",
         "webpack-cli": "^4.10.0",
         "webpack-node-externals": "^3.0.0"
+      },
+      "peerDependencies": {
+        "pyodide": ">=0.21.3"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -780,7 +782,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
       "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
-      "dev": true
+      "peer": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2501,7 +2503,7 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -2878,7 +2880,7 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.21.3.tgz",
       "integrity": "sha512-5fu5P8ys8V8tKTsK9lag0HattbZQuFRdnNzv1LLOLCieM9A96OPs2cF29lPpcD9N+8GuUtfrGCWEMKiupTHUlA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "base-64": "^1.0.0",
         "node-fetch": "^2.6.1",
@@ -3408,7 +3410,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "peer": true
     },
     "node_modules/ts-loader": {
       "version": "9.4.1",
@@ -3637,7 +3639,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "peer": true
     },
     "node_modules/webpack": {
       "version": "5.74.0",
@@ -3775,7 +3777,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -3837,7 +3839,7 @@
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
       "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4430,7 +4432,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
       "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
-      "dev": true
+      "peer": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -5689,7 +5691,7 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -5953,7 +5955,7 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.21.3.tgz",
       "integrity": "sha512-5fu5P8ys8V8tKTsK9lag0HattbZQuFRdnNzv1LLOLCieM9A96OPs2cF29lPpcD9N+8GuUtfrGCWEMKiupTHUlA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "base-64": "^1.0.0",
         "node-fetch": "^2.6.1",
@@ -6298,7 +6300,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "peer": true
     },
     "ts-loader": {
       "version": "9.4.1",
@@ -6454,7 +6456,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "peer": true
     },
     "webpack": {
       "version": "5.74.0",
@@ -6540,7 +6542,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -6590,7 +6592,7 @@
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
       "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
-      "dev": true,
+      "peer": true,
       "requires": {}
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "lodash": "^4.17.21",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
-    "pyodide": "^0.21.3",
     "ts-loader": "^9.4.1",
     "typescript": "^4.8.3",
     "webpack": "^5.74.0",
@@ -53,5 +52,8 @@
   },
   "dependencies": {
     "copy-webpack-plugin": "^11.0.0"
+  },
+  "peerDependencies": {
+    "pyodide": ">=0.21.3"
   }
 }


### PR DESCRIPTION
I'm using version 0.22.1 of Pyodide, and I get this error when creating Webpack bundle:

    ERROR in unable to locate '[...]/node_modules/pyodide/distutils.tar' glob

I assumed that version 0.22.1 of Pyodide doesn't have `distutils.tar`.
Removing `distutils.tar` from the files list fixed my issue and everything else seems to work.