### PR TITLE
Fix option `outDirectory` and `pyodideDependencyPath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ main();
 ## Options
 
 - [globalLoadPyodide](#globalLoadPyodide)
-- [outDirectory](#outDir)
+- [outDirectory](#outDirectory)
 - [packageIndexUrl](#packageIndexUrl)
 
 ### globalLoadPyodide
@@ -65,7 +65,7 @@ Default: `false`\
 Required: false\
 _Description_:Whether or not to expose loadPyodide method globally. A globalThis.loadPyodide is useful when using pyodide as a standalone script or in certain frameworks. With webpack we can scope the pyodide package locally to prevent leaks (default).
 
-### outDir
+### outDirectory
 
 Type: `string`\
 Default: `pyodide`\

--- a/index.ts
+++ b/index.ts
@@ -71,6 +71,9 @@ export class PyodidePlugin extends CopyPlugin {
     assert.ok(options.patterns.length > 0, `Unsupported version of pyodide. Must use >=${patterns.versions[0]}`);
     delete options.packageIndexUrl;
     delete options.globalLoadPyodide;
+    delete options.outDirectory;
+    delete options.version;
+    delete options.pyodideDependencyPath;
     super(options as Required<PyodideOptions>);
     this.globalLoadPyodide = globalLoadPyodide;
   }


### PR DESCRIPTION
When the option is set, CopyPlugin throws error:
```
Invalid options object. Copy Plugin has been initialized using an options object that does not match the API schema.

    - options has an unknown property 'outDirectory'. These properties are valid:
      object { patterns, options? }
```

The solution is to delete pyodide-webpack-plugin specific options before passing them to CopyPlugin

Note: the `version` option might be affected by the same bug too?