### PR TITLE
Fixes #14: Bump dev pyodide up to 0.23.0 and update patterns

### DIFF
--- a/lib/patterns.ts
+++ b/lib/patterns.ts
@@ -23,6 +23,7 @@ const files = {
     "pyodide.asm.wasm",
     "repodata.json",
   ],
+  "0.23.0": ["package.json", "pyodide.asm.js", "pyodide.asm.wasm", "repodata.json", "python_stdlib.zip"],
 };
 export const versions = Object.keys(files);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "mocha": "^10.2.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.7.1",
-        "pyodide": "^0.22.1",
+        "pyodide": "^0.23.0",
         "ts-loader": "^9.4.1",
         "typescript": "^4.8.3",
         "webpack": "^5.74.0",
@@ -3263,9 +3263,9 @@
       }
     },
     "node_modules/pyodide": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.22.1.tgz",
-      "integrity": "sha512-6+PkFLTC+kcBKtFQxYBxR44J5IBxLm8UGkobLgZv1SxzV9qOU2rb0YYf0qDtlnfDiN/IQd2uckf+D8Zwe88Mqg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.23.0.tgz",
+      "integrity": "sha512-7976PpL5PDeEhqRQYJLRM2iR9DFL71Fm+o6cTqQcZI3f+XWHyPg7dE4TTg5WMyCMVuMbgHGwWcm6lxIKTDbcFg==",
       "dev": true,
       "dependencies": {
         "base-64": "^1.0.0",
@@ -6805,9 +6805,9 @@
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
     },
     "pyodide": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.22.1.tgz",
-      "integrity": "sha512-6+PkFLTC+kcBKtFQxYBxR44J5IBxLm8UGkobLgZv1SxzV9qOU2rb0YYf0qDtlnfDiN/IQd2uckf+D8Zwe88Mqg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.23.0.tgz",
+      "integrity": "sha512-7976PpL5PDeEhqRQYJLRM2iR9DFL71Fm+o6cTqQcZI3f+XWHyPg7dE4TTg5WMyCMVuMbgHGwWcm6lxIKTDbcFg==",
       "dev": true,
       "requires": {
         "base-64": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "mocha": "^10.2.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
-    "pyodide": "^0.22.1",
+    "pyodide": "^0.23.0",
     "ts-loader": "^9.4.1",
     "typescript": "^4.8.3",
     "webpack": "^5.74.0",

--- a/test/pyodide-plugin.test.js
+++ b/test/pyodide-plugin.test.js
@@ -15,10 +15,8 @@ describe("pyodide webpack plugin", () => {
         assert.ok(files, "no files");
 
         assert.ok(files.indexOf("pyodide/pyodide.asm.wasm") !== -1);
-        assert.ok(files.indexOf("pyodide/pyodide.asm.data") !== -1);
         assert.ok(files.indexOf("pyodide/pyodide.asm.js") !== -1);
-
-        assert.ok(files.indexOf("pyodide/pyodide_py.tar") !== -1);
+        assert.ok(files.indexOf("pyodide/python_stdlib.zip") !== -1);
         assert.ok(files.indexOf("pyodide/repodata.json") !== -1);
         assert.ok(files.indexOf("pyodide/package.json") !== -1);
 


### PR DESCRIPTION
The list of files that pyodide requires to fetch/load later has changed in 0.23.x. Added a new .zip file and removed missing data files.