### PR TITLE
feat: add support pyodide 0.24.0 for #18

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -61,7 +61,7 @@ export class PyodidePlugin extends CopyPlugin {
     const pyodidePackagePath = tryGetPyodidePath(options.pyodideDependencyPath);
     const pkg = tryResolvePyodidePackage(pyodidePackagePath, options.version);
 
-    options.patterns = patterns.chooseAndTransform(pkg.version, options.packageIndexUrl).map((pattern) => {
+    options.patterns = patterns.chooseAndTransform(pkg, options.packageIndexUrl).map((pattern) => {
       return {
         from: path.resolve(pyodidePackagePath, pattern.from),
         to: path.join(outDirectory, pattern.to),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pyodide/webpack-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pyodide/webpack-plugin",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MPL-2.0",
       "dependencies": {
         "copy-webpack-plugin": "^11.0.0"
@@ -22,7 +22,7 @@
         "mocha": "^10.2.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.7.1",
-        "pyodide": "^0.23.0",
+        "pyodide": "^0.24.0",
         "ts-loader": "^9.4.1",
         "typescript": "^4.8.3",
         "webpack": "^5.74.0",
@@ -2758,26 +2758,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node_modules/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
@@ -3263,13 +3243,12 @@
       }
     },
     "node_modules/pyodide": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.23.0.tgz",
-      "integrity": "sha512-7976PpL5PDeEhqRQYJLRM2iR9DFL71Fm+o6cTqQcZI3f+XWHyPg7dE4TTg5WMyCMVuMbgHGwWcm6lxIKTDbcFg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.24.0.tgz",
+      "integrity": "sha512-k2TzIbAYQ/ucme0LYv4KmxKDR15m68/3pvPKmUVtdpzn6K9Qt1NLHeZI1RErWJE6PtlQI8UA0Q21wrtu3XPUMg==",
       "dev": true,
       "dependencies": {
         "base-64": "^1.0.0",
-        "node-fetch": "^2.6.1",
         "ws": "^8.5.0"
       }
     },
@@ -3952,12 +3931,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
-    },
     "node_modules/ts-loader": {
       "version": "9.4.2",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.2.tgz",
@@ -4119,12 +4092,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
-    },
     "node_modules/webpack": {
       "version": "5.76.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.0.tgz",
@@ -4272,16 +4239,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -6445,15 +6402,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-      "dev": true,
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
-    },
     "node-releases": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
@@ -6805,13 +6753,12 @@
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
     },
     "pyodide": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.23.0.tgz",
-      "integrity": "sha512-7976PpL5PDeEhqRQYJLRM2iR9DFL71Fm+o6cTqQcZI3f+XWHyPg7dE4TTg5WMyCMVuMbgHGwWcm6lxIKTDbcFg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.24.0.tgz",
+      "integrity": "sha512-k2TzIbAYQ/ucme0LYv4KmxKDR15m68/3pvPKmUVtdpzn6K9Qt1NLHeZI1RErWJE6PtlQI8UA0Q21wrtu3XPUMg==",
       "dev": true,
       "requires": {
         "base-64": "^1.0.0",
-        "node-fetch": "^2.6.1",
         "ws": "^8.5.0"
       }
     },
@@ -7280,12 +7227,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
-    },
     "ts-loader": {
       "version": "9.4.2",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.2.tgz",
@@ -7393,12 +7334,6 @@
         "graceful-fs": "^4.1.2"
       }
     },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
-    },
     "webpack": {
       "version": "5.76.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.0.tgz",
@@ -7490,16 +7425,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
       "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w=="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyodide/webpack-plugin",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Webpack plugin for integrating pyodide into your project",
   "exports": {
     ".": {
@@ -46,7 +46,7 @@
     "mocha": "^10.2.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
-    "pyodide": "^0.23.0",
+    "pyodide": "^0.24.0",
     "ts-loader": "^9.4.1",
     "typescript": "^4.8.3",
     "webpack": "^5.74.0",

--- a/test/pyodide-plugin.test.js
+++ b/test/pyodide-plugin.test.js
@@ -17,7 +17,7 @@ describe("pyodide webpack plugin", () => {
         assert.ok(files.indexOf("pyodide/pyodide.asm.wasm") !== -1);
         assert.ok(files.indexOf("pyodide/pyodide.asm.js") !== -1);
         assert.ok(files.indexOf("pyodide/python_stdlib.zip") !== -1);
-        assert.ok(files.indexOf("pyodide/repodata.json") !== -1);
+        assert.ok(files.indexOf("pyodide/pyodide-lock.json") !== -1);
         assert.ok(files.indexOf("pyodide/package.json") !== -1);
 
         done();


### PR DESCRIPTION
Addresses part of #12 by guessing which files are needed to go into the bundle based on pyodide package.json files list. Excludes some files like d.ts and .html files. Ensure certain files like package.json are always copied.